### PR TITLE
adding get_rms_value function

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In your `package.json` add the following, `"type": "module"`.
 # Example Usage
 
 ```js
-import { is_array, object_to_array, search_in_array,sanitize_array } from "@hetarth02/js-array-helpers";
+import { is_array, object_to_array, search_in_array,sanitize_array, get_rms_value } from "@hetarth02/js-array-helpers";
 
 let arr = [1, 2];
 console.log(is_array(arr)); // true
@@ -68,5 +68,17 @@ console.log(sanitize_array(my_array,my_schema));
 //      { name: '0', age: 123, isEmployed: false },
 //      { name: 'sam', age: 123, isEmployed: false } 
 // ]
+
+
+// get_rms_value example
+
+// Given array of numbers
+const values = [23, 54, 19];
+
+// Run get_rms_value with array
+console.log(get_rms_value(values))
+
+// Calculated Root Mean Square value
+// 35.61834733205159
 
 ```

--- a/index.js
+++ b/index.js
@@ -353,6 +353,18 @@ function get_only(arr, keys) {
     );
 }
 
+/**
+ * To get RMS (Root Mean Square) Value.
+ *
+ * @param array arr
+ * @returns number
+ */
+ function get_rms_value(arr) {
+    is_array(arr);
+    let sum_square = arr.reduce((ss, curr) => (isNaN(curr) ? 0 : ss + curr*curr), 0);
+    return Math.sqrt(sum_square/arr.length);
+  }
+
 export {
     is_array,
     is_num_array,
@@ -374,4 +386,5 @@ export {
     difference,
     sanitize_array,
     get_only,
+    get_rms_value,
 };


### PR DESCRIPTION
- get_rms_value
- This function returns the Root Mean Square (RMS) Value for a numeric array, this value is vital for many scientific calculations and formulae.
- I took this idea from my chemistry notebook.
- This function is limited to numeric arrays only i.e. it returns zero if it encounters elements of datatype other than number.

P.S. : This is my first contribution ever to an open source project so if I have done any mistake please let me know and I am ready to improve.